### PR TITLE
[FEATURE] remove default icon

### DIFF
--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -8,7 +8,7 @@
             <!-- Header -->
                 <header id="header">
                     <div class="logo">
-                        <a href="/"><span class="icon fa-{{ .Params.Icon | default "gem" }}"></span></a>
+                        <a href="/"><span class="icon fa-{{ .Params.Icon }}"></span></a>
                     </div>
                     <div class="content">
                         <div class="inner">


### PR DESCRIPTION
## Background 

Responding to issue https://github.com/your-identity/hugo-theme-dimension/issues/4 where @JustinTimperio was asking to remove the default icon. 

This PR removes the default gem icon allowing the user to remove the icon selection and be left with no logo

