### PR TITLE
Only create image span if defined

### DIFF
--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -45,7 +45,9 @@
                             {{if .Content }}
                                 <article id="{{ cond (in (.Title|urlize) "%") (.Title | base64Encode) (.Title) | urlize }}">
                                     <h2 class="major">{{ .Title }}</h2>
-                                    <span class="image main"><img src="{{ .Params.image }}" alt="" /></span>
+                                    {{if .Params.image }}
+                                        <span class="image main"><img src="{{ .Params.image }}" alt="" /></span>
+                                    {{ end }}
                                     {{ .Content }}
                                 </article>
                             {{ end }}


### PR DESCRIPTION
Fixes a random span that gets added to every post even when this archetype is not defined.