### PR TITLE
layouts: shortcodes: Add shortcode to allow CSS to apply to post images

### DIFF
--- a/layouts/shortcodes/image.html
+++ b/layouts/shortcodes/image.html
@@ -1,0 +1,8 @@
+{{ if .IsNamedParams }}
+    <span class="image {{ .Get "set" }}">
+        <img src="{{ .Get "src" }}" alt="{{ .Get "alt" }}" />
+    </span>
+{{ else }}
+    <span class="image {{ .Get 1 }}"><img src="{{ .Get 0 }}" alt="" /></span>
+{{ end }}
+


### PR DESCRIPTION
Addresses #10 

Example of shortcode usage is:
```
{{< image src="images/pic01.jpg" alt="My Post Image" set="left" >}}
```
And if an alt tag doesn't matter:
```
{{< image images/pic02.jpg fit >}}
```
Options to set image are based on currently available CSS from the original theme and are:

```main``` - Set the image similar to the 'image' archetype (i.e. the main image of a post)

```fit``` - Fit the image to the width of the post

```left``` - Set the image to the left half of the post

```right``` - Set the image to the right half of the post