### PR TITLE
[LOGO] use img rather than text

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,13 @@ to `config.toml` file in your Hugo root directory and change params fields.
 
 See the basic `_index.md` file params supported by the theme — https://github.com/your-identity/hugo-theme-dimension/blob/master/archetypes/_index.md
 
+```toml
+title: Your Name
+description: A great human
+background: "<path or link to image>"
+logo: "<path or link to image>"
+```
+
 ## How to run your site
 
 From your Hugo root directory run:

--- a/exampleSite/content/_index.md
+++ b/exampleSite/content/_index.md
@@ -2,5 +2,5 @@
 title: Your Name
 description: A great human
 background: "images/bg.jpg"
-logo: "https://upload.wikimedia.org/wikipedia/commons/d/da/Font_Awesome_5_solid_dragon.svg"
+logo: "https://upload.wikimedia.org/wikipedia/commons/8/8e/Font_Awesome_5_regular_gem.svg"
 ---

--- a/exampleSite/content/_index.md
+++ b/exampleSite/content/_index.md
@@ -2,4 +2,5 @@
 title: Your Name
 description: A great human
 background: "images/bg.jpg"
+logo: "https://upload.wikimedia.org/wikipedia/commons/d/da/Font_Awesome_5_solid_dragon.svg"
 ---

--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -8,7 +8,11 @@
             <!-- Header -->
                 <header id="header">
                     <div class="logo">
-                        <a href="/"><span class="icon fa-{{ .Params.Icon }}"></span></a>
+                        <a href="/">
+                            <span class="icon">
+                                <img src="{{ .Params.logo }}">
+                            </span>
+                        </a>
                     </div>
                     <div class="content">
                         <div class="inner">

--- a/static/assets/css/main.css
+++ b/static/assets/css/main.css
@@ -635,6 +635,15 @@ input, select, textarea {
 			font-family: 'Font Awesome 5 Brands';
 		}
 
+		.icon > img {
+			display: inline-block;
+			vertical-align: middle;
+			max-width: 3.5rem;
+			max-height: 3.5rem;
+			width: auto;
+			height: auto;
+		}
+
 /* Image */
 
 	.image {


### PR DESCRIPTION
## Background 

Some users requested the capability to add a custom logo to the header. Specifically #2 #3. 

## Breaking changes

This PR proposes to migrate away from font awesome entirely. This might be a breaking change
