### PR TITLE
Clarify background/icon usage in README, refine logo CSS

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,9 +60,9 @@ logo: "<path or link to image>"
 
 ### `background` and `logo` Params
 
-As indicated above, `background` and `image` can be a jpg of your choice by placing JPGs, PNGs, SVGs, etc. in the `static` directory of your repository. If the `static` directory does not yet exist, create it. 
+As indicated above, `background` and `logo` can be an image of your choice by placing JPGs, PNGs, SVGs, etc. in the `static` directory of your repository. If the `static` directory does not yet exist, create it. 
 
-With the following repo structure:
+Given the following repo structure:
 ```
   .
   ├── config.toml
@@ -96,7 +96,7 @@ With the following repo structure:
   ---
 ```
 
-Follow the same conventions as above for `logo`. **Alternatively**, both `background` and `logo` can be URLs to online resources.
+Follow the same conventions as demonstrated above for `logo`. 
 ## How to run your site
 
 From your Hugo root directory run:

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ A hugo port of HTML5UP's responsive and minimal dimension theme. With native sup
   - [How to start](#how-to-start)
   - [How to configure](#how-to-configure)
   - [Post archetype](#post-archetype)
+    - [`background` and `logo` Params](#background-and-logo-params)
   - [How to run your site](#how-to-run-your-site)
   - [How to contribute](#how-to-contribute)
   - [Sponsoring](#sponsoring)
@@ -57,6 +58,45 @@ background: "<path or link to image>"
 logo: "<path or link to image>"
 ```
 
+### `background` and `logo` Params
+
+As indicated above, `background` and `image` can be a jpg of your choice by placing JPGs, PNGs, SVGs, etc. in the `static` directory of your repository. If the `static` directory does not yet exist, create it. 
+
+With the following repo structure:
+```
+  .
+  ├── config.toml
+  ├── content
+  │   ├── posts
+  │   │   └── _index.md
+  │   ├── _index.md
+  │   └── elements.md
+  ├── static
+  │   └── images
+  │       └── custom_bg.jpg  
+  └── archetypes
+      └── default.md
+```
+
+`static/images/custom_bg.jpg` can be referenced in `content/_index.md` as:
+```yaml
+  ---
+  title: Your Name
+  description: A great human
+  background: "images/custom_bg.jpg"
+  ---
+```
+
+...or in `content/posts/_index.md` as:
+```yaml
+  ---
+  title: Posts
+  description: A great human's posts
+  background: "../images/custom_bg.jpg"
+  ---
+```
+
+Follow the same conventions as above for `logo`. **Alternatively**, both `background` and `logo` can be URLs to online resources.
 ## How to run your site
 
 From your Hugo root directory run:

--- a/README.md
+++ b/README.md
@@ -73,7 +73,8 @@ Given the following repo structure:
   │   └── elements.md
   ├── static
   │   └── images
-  │       └── custom_bg.jpg  
+  │       ├── custom_bg.jpg  
+  │       └── custom_logo.svg
   └── archetypes
       └── default.md
 ```
@@ -84,6 +85,7 @@ Given the following repo structure:
   title: Your Name
   description: A great human
   background: "images/custom_bg.jpg"
+  logo: "images/custom_logo.svg"
   ---
 ```
 
@@ -93,10 +95,19 @@ Given the following repo structure:
   title: Posts
   description: A great human's posts
   background: "../images/custom_bg.jpg"
+  logo: "../images/custom_logo.svg"
   ---
 ```
 
-Follow the same conventions as demonstrated above for `logo`. 
+Both fields may also be a URL to an online asset, such as:
+```yaml
+  ---
+  title: Posts
+  description: A great human's posts
+  logo: "https://upload.wikimedia.org/wikipedia/commons/8/8e/Font_Awesome_5_regular_gem.svg"
+  ---
+```
+
 ## How to run your site
 
 From your Hugo root directory run:

--- a/static/assets/css/main.css
+++ b/static/assets/css/main.css
@@ -157,6 +157,10 @@ input, select, textarea {
 		color: inherit;
 	}
 
+	.logo a {
+		border-bottom: unset;
+	}
+
 		a:hover {
 			border-bottom-color: transparent;
 		}


### PR DESCRIPTION
README clarification of proper usage of `background` and `image` parameters in the default archetype since Font Awesome usage was retired.

Refine CSS to remove dotted line `bottom-border` that appears on logos.