### PR TITLE
Add support for paths under root for baseURL.

### DIFF
--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -8,7 +8,7 @@
             <!-- Header -->
                 <header id="header">
                     <div class="logo">
-                        <a href="/">
+                        <a href="{{ .Params.baseURL }}">
                             <span class="icon">
                                 <img src="{{ .Params.logo }}">
                             </span>

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -12,7 +12,7 @@
                     </div>
                     <div class="content">
                         <div class="inner">
-                            <h1><a href="{{ "/" | relURL }}">Go Home</a></h1>
+                            <h1><a href="{{ .Params.baseURL }}">Go Home</a></h1>
                             <p>
                                 Nothing to see here
                             </p>


### PR DESCRIPTION
Basically, I have the need to host a page at example.com/projectname, vs say something like projectname.gitlab.com or similar. This should allow both.